### PR TITLE
Format the data in the FinanceReport vue component

### DIFF
--- a/src/services/FormatData.ts
+++ b/src/services/FormatData.ts
@@ -22,18 +22,36 @@ const formatFinanceData = async () => {
 // - NOI Margin (percentage)
 
 function formatAsTable(data: any[]) {
+
+    // This is a function that takes a number and returns a string
+    // This is useful for formatting the ADR column
+    const formatFn = (value: number) => {
+        // If value is float
+        if (value % 1 !== 0) {
+            return `${value.toFixed(2)}`;
+        }
+        return value.toString();
+    };
+
+    const dollarFormatFn = (value: number) => {
+        const formatted = formatFn(value);
+        return `$${formatted}`;
+    }
+
+    // We do not have to format the percentage to two decimal places
+    // because the vue-good-table-next library does it for us
     const columns = [
         { label: 'Hotel name', field: 'hotelName', type: 'string' },
         { label: 'Rooms', field: 'rooms', type: 'number' },
         { label: 'Occ', field: 'occ', type: 'percentage' },
-        { label: 'ADR', field: 'adr', type: 'number' },
-        { label: 'RevPar', field: 'revPar', type: 'number' },
-        { label: 'Total Rev', field: 'totalRev', type: 'number' },
-        { label: 'GOP', field: 'gop', type: 'number' },
+        { label: 'ADR', field: 'adr', type: 'number', formatFn: dollarFormatFn},
+        { label: 'RevPar', field: 'revPar', type: 'number', formatFn: formatFn},
+        { label: 'Total Rev', field: 'totalRev', type: 'number', formatFn: formatFn},
+        { label: 'GOP', field: 'gop', type: 'number', formatFn: formatFn},
         { label: 'GOP Margin', field: 'gopMargin', type: 'percentage' },
-        { label: 'EBITDA', field: 'ebitda', type: 'number' },
+        { label: 'EBITDA', field: 'ebitda', type: 'number', formatFn: formatFn},
         { label: 'EBITDA Margin', field: 'ebitdaMargin', type: 'percentage' },
-        { label: 'NOI', field: 'noi', type: 'number' },
+        { label: 'NOI', field: 'noi', type: 'number', formatFn: formatFn},
         { label: 'NOI Margin', field: 'noiMargin', type: 'percentage' },
     ];
 


### PR DESCRIPTION
As per requested in #7, changes were implemented in src/services/FormatData.ts to implement a format function for some of the columns to answer client's needs.

All numbers should properly be formated to 2 decimal places, percentage should show a % sign (this is by default with the 'percentage' type in vue-good-table-next as is the 2 decimal places) and it should prepend a dollar sign to monetary amount representations.